### PR TITLE
Feat/#37 게시글 작성 페이지 / 게시글 상세 페이지 API 연동

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "aws-sdk": "^2.1413.0",
     "axios": "^1.3.6",
     "date-fns": "^2.29.3",
-    "dayjs": "^1.11.7",
+    "dayjs": "^1.11.10",
     "eslint": "8.36.0",
     "eslint-config-next": "13.2.4",
     "framer-motion": "^10.12.4",

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "react-slick": "^0.29.0",
     "sass": "^1.61.0",
     "slick-carousel": "^1.8.1",
+    "swr": "^2.2.4",
     "typescript": "5.0.2",
     "uuid": "^9.0.0"
   },

--- a/src/api/post.ts
+++ b/src/api/post.ts
@@ -1,12 +1,24 @@
 import { PostSubmit } from '@/types/post/post';
 import { authInstance } from './axiosCustom';
 import { ApiResponseWithDataType } from '@/types/apiResponseType';
+import { DetailBoardType } from '@/types/board';
 
 export const onPostAPI = async (form: PostSubmit) => {
   try {
     const response = await authInstance.post<
       ApiResponseWithDataType<{ id: string }>
     >('/posts', form);
+    return response.data.data;
+  } catch (e) {
+    return Promise.reject(e);
+  }
+};
+
+export const getPostAPI = async (postId: string) => {
+  try {
+    const response = await authInstance.get<
+      ApiResponseWithDataType<DetailBoardType>
+    >(`/posts/${postId}`);
     return response.data.data;
   } catch (e) {
     return Promise.reject(e);

--- a/src/api/post.ts
+++ b/src/api/post.ts
@@ -1,0 +1,14 @@
+import { PostSubmit } from '@/types/post/post';
+import { authInstance } from './axiosCustom';
+import { ApiResponseWithDataType } from '@/types/apiResponseType';
+
+export const onPostAPI = async (form: PostSubmit) => {
+  try {
+    const response = await authInstance.post<
+      ApiResponseWithDataType<{ id: string }>
+    >('/posts', form);
+    return response.data.data;
+  } catch (e) {
+    return Promise.reject(e);
+  }
+};

--- a/src/components/Calendar/index.tsx
+++ b/src/components/Calendar/index.tsx
@@ -25,14 +25,20 @@ const MONTHS = [
   'December',
 ];
 
-export default function CalendarInput() {
-  const [value, onChange] = useState<Date | null>();
+type CalendarInputProps = {
+  deadline: Date | null | undefined;
+  setDeadline: React.Dispatch<React.SetStateAction<Date | null | undefined>>;
+};
 
+export default function CalendarInput({
+  deadline,
+  setDeadline,
+}: CalendarInputProps) {
   return (
     <CustomCalendar
-      selected={value || null}
+      selected={deadline || null}
       shouldCloseOnSelect
-      onChange={(date: Date) => onChange(date)}
+      onChange={(date: Date) => setDeadline(date)}
       onChangeRaw={(e) => e.preventDefault()}
       onFocus={(e) => e.target.blur()}
       dateFormat="yyyy-MM-dd"
@@ -42,7 +48,7 @@ export default function CalendarInput() {
       placeholderText="마감 날짜를 선택하세요."
       calendarClassName={styles.calenderWrapper}
       dayClassName={(d) =>
-        value && d.getDate() === value!.getDate()
+        deadline && d.getDate() === deadline!.getDate()
           ? styles.selectedDay
           : styles.unselectedDay
       }
@@ -77,7 +83,6 @@ export default function CalendarInput() {
               className={styles.monthButton}
               disabled={prevMonthButtonDisabled}
             >
-              {/* <LeftArrow fill='#ffffff' /> */}
               <p>&lt;</p>
             </button>
             <button
@@ -86,7 +91,6 @@ export default function CalendarInput() {
               className={styles.monthButton}
               disabled={nextMonthButtonDisabled}
             >
-              {/* <RightArrow fill='#ffffff' /> */}
               <p>&gt;</p>
             </button>
           </div>
@@ -96,18 +100,6 @@ export default function CalendarInput() {
   );
 }
 
-// const Container = styled.div`
-//   height: 4.6rem;
-//   border: 1px solid ${(props) => props.theme.main_brown};
-//   border-radius: 6px;
-//   padding: 0.5em;
-//   outline: none;
-//   font-size: 1.6rem;
-//   color: ${(props) => props.theme.text_color};
-//   & input {
-//     color: ${(props) => props.theme.text_color};
-//   }
-// `;
 const CustomCalendar = styled(DatePicker)`
   width: 100%;
   height: 4.6rem;

--- a/src/components/common/BoardCardItem/index.tsx
+++ b/src/components/common/BoardCardItem/index.tsx
@@ -28,7 +28,7 @@ function BoardCardItem({ card }: BoardCardItemProps) {
   };
 
   return (
-    <Div onClick={() => router.push('/posts/1')}>
+    <Div onClick={() => router.push(`/posts/${card.id}`)}>
       <>
         <section
           style={{

--- a/src/components/common/BoardCardItem/index.tsx
+++ b/src/components/common/BoardCardItem/index.tsx
@@ -21,6 +21,12 @@ type BoardCardItemProps = { card: BoardType };
 function BoardCardItem({ card }: BoardCardItemProps) {
   const router = useRouter();
 
+  const getHeadCount = (headCount: string) => {
+    if (headCount === 'undecided') return '미정';
+    else if (headCount === 'over 6') return '6명 이상';
+    else return headCount;
+  };
+
   return (
     <Div onClick={() => router.push('/posts/1')}>
       <>
@@ -48,7 +54,7 @@ function BoardCardItem({ card }: BoardCardItemProps) {
         </section>
         <section>
           <LetterDiv style={{ fontSize: '2.6rem' }}>{card.title}</LetterDiv>
-          <LetterDiv>{card.content}</LetterDiv>
+          <LetterDiv>{card.content.replace(/<[^>]*>/g, '')}</LetterDiv>
         </section>
       </>
 
@@ -72,7 +78,7 @@ function BoardCardItem({ card }: BoardCardItemProps) {
         <InfoIconBox>
           <InfoIconItem style={{ marginRight: '1rem' }}>
             <RxPerson />
-            <div>{card.headcount}</div>
+            <div>{getHeadCount(card.headcount)}</div>
           </InfoIconItem>
           <InfoIconItem style={{ marginLeft: '1rem' }}>
             <TbMessageCircle2 />
@@ -155,8 +161,7 @@ const InfoIconBox = styled.div`
 const InfoIconItem = styled.div`
   font-size: 2rem;
   display: flex;
-  width: 4rem;
-  justify-content: space-between;
+  gap: 0.5rem;
 `;
 
 export default BoardCardItem;

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -50,7 +50,7 @@ export default function Home() {
         dispatch(setIsLogin(false));
       }
     }
-  }, []);
+  }, [dispatch, user.user.id]);
 
   useEffect(() => {
     const config: AxiosRequestConfig = {

--- a/src/pages/posts/[postId].tsx
+++ b/src/pages/posts/[postId].tsx
@@ -1,6 +1,5 @@
 import { useRouter } from 'next/router';
 import React, { useState } from 'react';
-import { PostType } from '@/types/post/post';
 import backIcon from '@/assets/backIcon.png';
 import noLikeIcon from '@/assets/noLike.png';
 import enterIcon from '@/assets/enterIcon.svg';
@@ -11,56 +10,15 @@ import Comment from '@/components/Comment';
 import getTechImageURL from '@/utils/getTechImageUrl';
 import SendNote from '@/components/SendNote';
 import styled from '@emotion/styled';
-
-const DUMMY_DATA: PostType = {
-  id: 1,
-  title: '[ React ] 프로젝트 급구!',
-  project_name: 'MoaMoa',
-  content:
-    '<p><h1>저희는 리액트 프로젝트를 진행하려고 합니다😄</h1> <br/> <h3>Frontend에 능숙하신 분을 구하고 있습니다!</h3> <br/> 프로젝트 관심 있으신 분은 쪽지나 댓글 부탁드립니다 :)</p>',
-  deadline: new Date('June 17, 2023 03:24:00'),
-  headcount: 6,
-  job_position: 'ALL',
-  user: {
-    id: 1,
-    nickname: '송지민',
-    image_url:
-      'https://image.idus.com/image/files/21e9ae9b65fd4fcf9d87c1ecb6c85a5d_720.jpg',
-  },
-  tech_stack_list: [
-    {
-      id: 1,
-    },
-    {
-      id: 3,
-    },
-  ],
-  comment_list: [
-    {
-      id: 17,
-      content: '저 신청하고 싶습니다',
-      user: {
-        id: 2,
-        nickname: '강민아',
-        image_url:
-          'https://image.idus.com/image/files/21e9ae9b65fd4fcf9d87c1ecb6c85a5d_720.jpg',
-      },
-    },
-    {
-      id: 24,
-      content: '저요',
-      user: {
-        id: 1,
-        nickname: '송지민',
-        image_url:
-          'https://image.idus.com/image/files/21e9ae9b65fd4fcf9d87c1ecb6c85a5d_720.jpg',
-      },
-    },
-  ],
-};
+import { getPostAPI } from '@/api/post';
+import useSWR from 'swr';
+import Avatar from '@/assets/avatar.png';
 
 export default function Post() {
   const router = useRouter();
+
+  const { data: postData } = useSWR(`${router.query.postId}`, getPostAPI);
+
   const [likeState, setLikeState] = useState(false);
   const [isNoteOpen, setIsNoteOpen] = useState(false);
 
@@ -68,15 +26,29 @@ export default function Post() {
     setIsNoteOpen((prev) => !prev);
   };
 
+  const getHeadCount = (headCount: string) => {
+    if (headCount === 'undecided') return '인원 미정';
+    if (headCount === 'over 6') return '6명 이상';
+    else return `${headCount}명`;
+  };
+
+  if (!postData) {
+    return <div>존재하지 않는 게시글입니다.</div>;
+  }
+
   return (
     <PostWrapper>
       <BackIconWrapper onClick={() => router.push('/')}>
         <Image src={backIcon} alt="backIcon" fill />
       </BackIconWrapper>
-      <h1>{DUMMY_DATA.title}</h1>
+      <h1>{postData.title || ''}</h1>
       <DescriptionWrapper>
         <ProfileImage>
-          <Image src={DUMMY_DATA.user.image_url} alt="profileImage" fill />
+          <Image
+            src={postData.user.image_url || Avatar}
+            alt="profileImage"
+            fill
+          />
         </ProfileImage>
         <OptionBox>
           <OptionImage>
@@ -108,36 +80,36 @@ export default function Post() {
         <DescriptionBox>
           <Description>
             <p>작성자</p>
-            <text>{DUMMY_DATA.user.nickname}</text>
+            <text>{postData.user.nickname || ''}</text>
           </Description>
           <Description>
             <p>프로젝트명</p>
-            <text>{DUMMY_DATA.project_name}</text>
+            <text>{postData.project_name || ''}</text>
           </Description>
           <Description>
             <p>생성일</p>
-            <text>{dayjs(new Date()).format('YYYY.MM.DD')}</text>
+            <text>{dayjs(postData.created_at || '').format('YYYY.MM.DD')}</text>
           </Description>
           <Description>
             <p>모집 분야</p>
             <ul>
-              {['프론트엔드', '백엔드'].map((position, idx) => (
+              {(postData.job_tag || []).map((position, idx) => (
                 <OptionBadge key={idx}>{position}</OptionBadge>
               ))}
             </ul>
           </Description>
           <Description>
             <p>모집 인원</p>
-            <text>{DUMMY_DATA.headcount}명</text>
+            <text>{getHeadCount(postData.headcount || '0')}</text>
           </Description>
           <Description>
             <p>모집 마감</p>
-            <text>{dayjs(DUMMY_DATA.deadline).format('YYYY.MM.DD')}</text>
+            <text>{dayjs(postData.deadline || '').format('YYYY.MM.DD')}</text>
           </Description>
           <Description>
             <p>사용 기술</p>
             <ul>
-              {DUMMY_DATA.tech_stack_list.map((tech) => (
+              {(postData.tech_stack_list || []).map((tech) => (
                 <TechIcon key={tech.id}>
                   <Image
                     src={getTechImageURL(tech.id) || ''}
@@ -151,16 +123,17 @@ export default function Post() {
         </DescriptionBox>
       </DescriptionWrapper>
       <h3>
-        모집마감 {dayjs(DUMMY_DATA.deadline).diff(dayjs(new Date()), 'days')}일
+        모집마감{' '}
+        {dayjs(postData.deadline || '').diff(dayjs(new Date()), 'days')}일
         남았어요!
       </h3>
       <Introduce className="introduce">
         <h1>프로젝트 소개</h1>
         <hr />
-        <div dangerouslySetInnerHTML={{ __html: DUMMY_DATA.content }} />
+        <div dangerouslySetInnerHTML={{ __html: postData.content || '' }} />
       </Introduce>
       <CommentWrapper>
-        <h1>{DUMMY_DATA.comment_list.length}개의 댓글이 있습니다.</h1>
+        <h1>{postData.comment_list.length || ''}개의 댓글이 있습니다.</h1>
         <InputWrapper>
           <textarea placeholder="내용을 입력하세요." />
           <ClickButton>
@@ -168,7 +141,7 @@ export default function Post() {
           </ClickButton>
         </InputWrapper>
         <CommentList>
-          {DUMMY_DATA.comment_list.map((comment) => (
+          {(postData.comment_list || []).map((comment) => (
             <Comment
               key={comment.id}
               content={comment.content}

--- a/src/types/board/index.ts
+++ b/src/types/board/index.ts
@@ -24,7 +24,7 @@ export type BoardType = {
   project_name: string;
   content: string;
   deadline: Date;
-  headcount: number;
+  headcount: string;
   job_tag: string[];
   user: User;
   tech_stack_list: TechStackList[];

--- a/src/types/board/index.ts
+++ b/src/types/board/index.ts
@@ -32,6 +32,20 @@ export type BoardType = {
   created_at: Date;
 };
 
+export type DetailBoardType = Omit<BoardType, 'comment_count'> & {
+  comment_list: Comment[];
+};
+
+export type Comment = {
+  id: number;
+  content: string;
+  user: {
+    id: number;
+    nickname: string;
+    image_url: string;
+  };
+};
+
 export type TechStackList = {
   id: number;
 };
@@ -39,7 +53,7 @@ export type TechStackList = {
 export type User = {
   id: number;
   nickname: string;
-  image_url: null;
+  image_url: string;
 };
 
 export type Sort = {

--- a/src/types/post/post.ts
+++ b/src/types/post/post.ts
@@ -26,3 +26,13 @@ export type User = {
 export type TechStackList = {
   id: number;
 };
+
+export type PostSubmit = {
+  title: string;
+  project_name: string;
+  content: string;
+  deadline: string;
+  headcount: string;
+  job_tag: string[];
+  tech_stack_arr: string[];
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -1926,10 +1926,10 @@ date-fns@^2.0.1, date-fns@^2.24.0, date-fns@^2.29.3:
   dependencies:
     "@babel/runtime" "^7.21.0"
 
-dayjs@^1.11.7:
-  version "1.11.7"
-  resolved "https://registry.yarnpkg.com/dayjs/-/dayjs-1.11.7.tgz#4b296922642f70999544d1144a2c25730fce63e2"
-  integrity sha512-+Yw9U6YO5TQohxLcIkrXBeY73WP3ejHWVvx8XCk3gxvQDCTEmS48ZrSZCKciI7Bhl/uCMyxYtE9UqRILmFphkQ==
+dayjs@^1.11.10:
+  version "1.11.10"
+  resolved "https://registry.yarnpkg.com/dayjs/-/dayjs-1.11.10.tgz#68acea85317a6e164457d6d6947564029a6a16a0"
+  integrity sha512-vjAczensTgRcqDERK0SR2XMwsF/tSvnvlv6VcF2GIhg6Sx4yOIt/irsr1RDJsKiIyBzJDpCoXiWWq28MqH2cnQ==
 
 debug@4, debug@^4.1.0, debug@^4.1.1, debug@^4.3.2, debug@^4.3.4:
   version "4.3.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1773,7 +1773,7 @@ cli-truncate@^3.1.0:
     slice-ansi "^5.0.0"
     string-width "^5.0.0"
 
-client-only@0.0.1:
+client-only@0.0.1, client-only@^0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/client-only/-/client-only-0.0.1.tgz#38bba5d403c41ab150bff64a95c85013cf73bca1"
   integrity sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==
@@ -5047,6 +5047,14 @@ supports-preserve-symlinks-flag@^1.0.0:
   resolved "https://registry.yarnpkg.com/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz#6eda4bd344a3c94aea376d4cc31bc77311039e09"
   integrity sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==
 
+swr@^2.2.4:
+  version "2.2.4"
+  resolved "https://registry.yarnpkg.com/swr/-/swr-2.2.4.tgz#03ec4c56019902fbdc904d78544bd7a9a6fa3f07"
+  integrity sha512-njiZ/4RiIhoOlAaLYDqwz5qH/KZXVilRLvomrx83HjzCWTfa+InyfAjv05PSFxnmLzZkNO9ZfvgoqzAaEI4sGQ==
+  dependencies:
+    client-only "^0.0.1"
+    use-sync-external-store "^1.2.0"
+
 symbol-tree@^3.2.4:
   version "3.2.4"
   resolved "https://registry.yarnpkg.com/symbol-tree/-/symbol-tree-3.2.4.tgz#430637d248ba77e078883951fb9aa0eed7c63fa2"
@@ -5263,7 +5271,7 @@ url@0.10.3:
     punycode "1.3.2"
     querystring "0.2.0"
 
-use-sync-external-store@^1.0.0:
+use-sync-external-store@^1.0.0, use-sync-external-store@^1.2.0:
   version "1.2.0"
   resolved "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.2.0.tgz#7dbefd6ef3fe4e767a0cf5d7287aacfb5846928a"
   integrity sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==


### PR DESCRIPTION
## 📖 개요
게시글 작성/상세 페이지 API 연동

## 💻 작업사항

- 게시글 작성 페이지 API 연동
- 게시글 상세 페이지 API 연동
- SWR 라이브러리 사용

## 💡 작성한 이슈 외에 작업한 사항
- 메인페이지 게시글 카드에 있는 콘텐츠 텍스트 태그 제거

## trouble shooting
게시글 상세 페이지에서는 getServerSideProps를 통해 SSR로 작성하려고 했으나..
localStorage에 저장된 token값을 서버사이드에서 가져올 수 없어서 아예 불가능하다.
서버사이드에서도 동작시키기 위해서는 토큰을 localStorage가 아닌 cookie에 저장하면 가능하다고 한다.

## ✔️ check list

- [ ] 작성한 이슈의 내용을 전부 적용했나요?
- [ ] 리뷰어를 등록했나요?
